### PR TITLE
Файловый сервер

### DIFF
--- a/fileserver/fshandlers/fshandlers.go
+++ b/fileserver/fshandlers/fshandlers.go
@@ -1,0 +1,91 @@
+package fshandlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"path/filepath"
+)
+
+type UploadHandler struct {
+	ServerAddr string
+	ServeDir   string
+}
+
+func (h *UploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		log.Print("cannot read file")
+		http.Error(w, "Unable to read file", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		http.Error(w, "Unable to read file", http.StatusBadRequest)
+		return
+	}
+
+	filePath := h.ServeDir + "/" + header.Filename
+
+	err = ioutil.WriteFile(filePath, data, 0777)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, "Unable to save file", http.StatusInternalServerError)
+		return
+	}
+
+	fileLink := "http://" + h.ServerAddr + "/" + header.Filename
+	fmt.Fprintln(w, fileLink)
+}
+
+type FileData struct {
+	Name string
+	Ext  string
+	Size int64
+}
+
+type ListHandler struct {
+	ServeDir string
+}
+
+func (h *ListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	if r.Method != http.MethodGet {
+		http.Error(w, "GET-method expected", http.StatusBadRequest)
+		return
+	}
+
+	files, err := ioutil.ReadDir(h.ServeDir)
+	if err != nil {
+		log.Printf("cannot read file from directory %s", h.ServeDir)
+		http.Error(w, "Unable to read directory", http.StatusBadRequest)
+		return
+	}
+
+	ext := r.FormValue("ext")
+	var filesData []FileData
+	for _, someFile := range files {
+		if !someFile.IsDir() {
+			fileAttr := FileData{
+				Name: someFile.Name(),
+				Ext:  filepath.Ext(someFile.Name()),
+				Size: someFile.Size(),
+			}
+			if ext == "" || fileAttr.Ext == ext {
+				filesData = append(filesData, fileAttr)
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(w).Encode(filesData)
+	if err != nil {
+		log.Printf("cannot convert data into json %v", err)
+		http.Error(w, "Unable to read directory", http.StatusBadRequest)
+		return
+	}
+}

--- a/fileserver/fshandlers/fshandlers_test.go
+++ b/fileserver/fshandlers/fshandlers_test.go
@@ -1,0 +1,108 @@
+package fshandlers
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUploadHandler(t *testing.T) {
+	// открываем файл, который хотим отправить
+	file, err := os.Open("testfile.txt")
+	if err != nil {
+		fmt.Println(err)
+		t.Fatal("error opening 'testfile.txt'")
+	}
+	defer file.Close()
+
+	// действия, необходимые для того, чтобы засунуть файл в запрос
+	// в качестве мультипарт-формы
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, _ := writer.CreateFormFile("file", filepath.Base(file.Name()))
+	_, err = io.Copy(part, file)
+	if err != nil {
+		t.Fatalf("error creating multipart form, %v", err)
+	}
+	writer.Close()
+
+	// опять создаем запрос, теперь уже на /upload эндпоинт
+	req, _ := http.NewRequest(http.MethodPost, "/upload", body)
+	req.Header.Add("Content-Type", writer.FormDataContentType())
+
+	// создаем ResponseRecorder
+	rr := httptest.NewRecorder()
+
+	// создаем заглушку файлового сервера. Для прохождения тестов
+	// нам достаточно чтобы он возвращал 200 статус
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "ok!")
+	}))
+	defer ts.Close()
+
+	uploadHandler := &UploadHandler{
+		// таким образом мы подменим адрес файлового сервера
+		// и вместо реального, хэндлер будет стучаться на заглушку
+		// которая всегда будет возвращать 200 статус, что нам и нужна
+		ServerAddr: ts.URL,
+		ServeDir:   "./files",
+	}
+
+	// опять же, вызываем ServeHTTP у тестируемого обработчика
+	uploadHandler.ServeHTTP(rr, req)
+
+	// Проверяем статус-код ответа
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	expected := `testfile.txt`
+	if !strings.Contains(rr.Body.String(), expected) {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
+}
+
+func TestListHandler(t *testing.T) {
+	body := &bytes.Buffer{}
+	req, _ := http.NewRequest(http.MethodGet, "/list?ext=.txt", body)
+
+	// создаем ResponseRecorder
+	rr := httptest.NewRecorder()
+
+	// создаем заглушку файлового сервера.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "ok!")
+	}))
+	defer ts.Close()
+
+	listHandler := &ListHandler{
+		// таким образом мы подменим адрес файлового сервера
+		// и вместо реального, хэндлер будет стучаться на заглушку
+		// которая всегда будет возвращать 200 статус, что нам и нужна
+		ServeDir: "./files",
+	}
+
+	// опять же, вызываем ServeHTTP у тестируемого обработчика
+	listHandler.ServeHTTP(rr, req)
+
+	// Проверяем статус-код ответа
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	expected := `testfile.txt`
+	if !strings.Contains(rr.Body.String(), expected) {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
+}

--- a/fileserver/handlers/handlers.go
+++ b/fileserver/handlers/handlers.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type Handler struct {
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		name := r.FormValue("name")
+		fmt.Fprintf(w, "Parsed query-param with key \"name\": %s", name)
+	case http.MethodPost:
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Unable to read request body", http.StatusBadRequest)
+			return
+		}
+		defer r.Body.Close()
+		fmt.Fprintf(w, "Parsed request body: %s\n", string(body))
+	}
+}

--- a/fileserver/server/server.go
+++ b/fileserver/server/server.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/pankratsdarya/gobackendone/fileserver/fshandlers"
+	"github.com/pankratsdarya/gobackendone/fileserver/handlers"
+)
+
+func main() {
+	handler := &handlers.Handler{}
+	uploadHandler := &fshandlers.UploadHandler{
+		ServerAddr: "localhost:8080",
+		ServeDir:   "./files",
+	}
+	listHandler := &fshandlers.ListHandler{
+		ServeDir: "./files",
+	}
+
+	http.Handle("/", handler)
+	http.Handle("/upload", uploadHandler)
+	http.Handle("/list", listHandler)
+
+	srv := &http.Server{
+		Addr:         ":80",
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	dirToServe := http.Dir(uploadHandler.ServeDir)
+	fs := &http.Server{
+		Addr:         ":8080",
+		Handler:      http.FileServer(dirToServe),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		err := srv.ListenAndServe()
+		if err != nil {
+			fmt.Println("error starting server")
+			return
+		}
+	}()
+
+	go func() {
+		err := fs.ListenAndServe()
+		if err != nil {
+			fmt.Println("error starting server")
+			return
+		}
+	}()
+
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
+
+	killsignal := <-interrupt
+	switch killsignal {
+	case os.Interrupt:
+		log.Print("Got SIGINT...")
+	case syscall.SIGTERM:
+		log.Print("Got SIGTERM...")
+	}
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelFunc()
+	err := srv.Shutdown(ctx)
+	if err != nil {
+		log.Printf("Error while shutting down the server: %v", err)
+	} else {
+		log.Print("Server stopped.")
+	}
+	err = fs.Shutdown(ctx)
+	if err != nil {
+		log.Printf("Error while shutting down the fileserver: %v", err)
+	} else {
+		log.Print("Fileserver stopped.")
+	}
+
+}


### PR DESCRIPTION
1. Реализована возможность получить список всех файлов на сервере (имя, расширение, размер в байтах).
Для получения списка файлов (с фильтром или без) используется GET-запрос с маршрутом /list (пакет fshandlers тип ListHandler) http://localhost:8080/list.
2. Реализована  фильтрация по расширению с помощью query-параметра (ключ ext).
3. Добавлен graсeful shutdown.